### PR TITLE
v2.0.1: ids() separator backwards compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,9 @@ $beers = $punkApi->ids([1, 5, 10])->getBeers();
 
 ## Changelog
 
+#### v 2.0.1
+* Bugfix - `ids()` now normalizes separators automatically (pipes → commas on v3, commas → pipes on v2) so existing code passing pipe-separated strings continues to work
+
 #### v 2.0.0
 * **Breaking**: Removed API key parameter from constructor (v3 API requires no auth)
 * **Breaking**: Requires PHP >= 8.3

--- a/src/PunkApi.php
+++ b/src/PunkApi.php
@@ -464,6 +464,16 @@ class PunkApi
         {
             $separator = $this->apiVersion === 'v3' ? ',' : '|';
             $ids = join($separator, $ids);
+        } else
+        {
+            // Normalize separator for the active API version
+            if ($this->apiVersion === 'v3')
+            {
+                $ids = str_replace('|', ',', $ids);
+            } else
+            {
+                $ids = str_replace(',', '|', $ids);
+            }
         }
 
         $this->addParams(['ids' => $ids]);

--- a/tests/PunkApiTest.php
+++ b/tests/PunkApiTest.php
@@ -94,6 +94,20 @@ class PunkApiTest extends TestCase
         $this->assertStringContainsString('ids=1,2,3', urldecode($endpoint));
     }
 
+    public function testIdsNormalizesPipesToCommasForV3(): void
+    {
+        $api = new PunkApi('v3');
+        $endpoint = $api->ids('1|2|3')->getEndpoint();
+        $this->assertStringContainsString('ids=1,2,3', urldecode($endpoint));
+    }
+
+    public function testIdsNormalizesCommasToPipesForV2(): void
+    {
+        $api = new PunkApi('v2');
+        $endpoint = $api->ids('1,2,3')->getEndpoint();
+        $this->assertStringContainsString('ids=1|2|3', urldecode($endpoint));
+    }
+
     public function testAbvAboveSetsEndpoint(): void
     {
         $endpoint = $this->punkApi->abvAbove(10)->getEndpoint();


### PR DESCRIPTION
## v2.0.1 — ids() separator backwards compatibility

### Fix
- `ids()` now normalizes separators automatically — pipes (`|`) are converted to commas on v3, and commas to pipes on v2
- Existing code passing pipe-separated strings (e.g. `ids('1|5|10')`) continues to work without changes when upgrading to v3

### Tests
- Added 2 new tests for separator normalization (47 tests, 136 assertions total)
