### PR TITLE
Regenerate API docs for v2.0.1

### DIFF
--- a/docs/classes/billythekid-PunkApi.html
+++ b/docs/classes/billythekid-PunkApi.html
@@ -2105,7 +2105,7 @@ replicating the API&#039;s filtering and pagination behavior.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/PunkApi.php"><a href="files/src-punkapi.html"><abbr title="src/PunkApi.php">PunkApi.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">517</span>
+    <span class="phpdocumentor-element-found-in__line">527</span>
 
     </aside>
 
@@ -2154,7 +2154,7 @@ replicating the API&#039;s filtering and pagination behavior.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/PunkApi.php"><a href="files/src-punkapi.html"><abbr title="src/PunkApi.php">PunkApi.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">562</span>
+    <span class="phpdocumentor-element-found-in__line">572</span>
 
     </aside>
 
@@ -2204,7 +2204,7 @@ replicating the API&#039;s filtering and pagination behavior.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/PunkApi.php"><a href="files/src-punkapi.html"><abbr title="src/PunkApi.php">PunkApi.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">535</span>
+    <span class="phpdocumentor-element-found-in__line">545</span>
 
     </aside>
 
@@ -2249,7 +2249,7 @@ replicating the API&#039;s filtering and pagination behavior.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/PunkApi.php"><a href="files/src-punkapi.html"><abbr title="src/PunkApi.php">PunkApi.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">484</span>
+    <span class="phpdocumentor-element-found-in__line">494</span>
 
     </aside>
 
@@ -2302,7 +2302,7 @@ full v2 URLs (https://images.punkapi.com/v2/...), and already-normalized URLs.</
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/PunkApi.php"><a href="files/src-punkapi.html"><abbr title="src/PunkApi.php">PunkApi.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">717</span>
+    <span class="phpdocumentor-element-found-in__line">727</span>
 
     </aside>
 


### PR DESCRIPTION
Updates the phpDocumentor-generated class documentation to reflect the ids() separator normalization added in v2.0.1.